### PR TITLE
feat: trim whitespace

### DIFF
--- a/test/expect/result_trim-whitespace.html
+++ b/test/expect/result_trim-whitespace.html
@@ -1,0 +1,7 @@
+No line breaks <span>are inserted,</span> because "block" and "extend" are control tags... <i>...which can't dictate vertical indentation.</i>
+
+I am indented according to the file which should control it — base.html.
+
+
+
+<b>^^^ 3 empty lines above me (and no empty lines below), as per base.html.</b>

--- a/test/extend.js
+++ b/test/extend.js
@@ -16,6 +16,14 @@ let mfs = {
         this._files[fullPath] = content;
     }
 };
+const join = require('path').join;
+const readSync = require('fs').readFileSync;
+const fixture = (file) => {
+    return readSync(join(__dirname, 'fixtures', `${file}.html`), 'utf8');
+};
+const result = (file) => {
+    return readSync(join(__dirname, 'expect', `${file}.html`), 'utf8');
+};
 
 const extend = proxyquire('../lib/extend', {
     fs: mfs
@@ -199,6 +207,15 @@ describe('Extend', () => {
             init('<extends src="layout.html"><block name="head"></block></extends>'),
             '[posthtml-extend] Unexpected block "head"'
         );
+    });
+
+    it('should remove all whitespace at the start/end of the first/last text node', () => {
+        mfs.writeFileSync( './base.html', fixture('base_trim-whitespace'));
+        mfs.writeFileSync( './layout.html', fixture('layout_trim-whitespace'));
+
+        return init(fixture('test_trim-whitespace')).then(html => {
+            expect(html).toBe(result('result_trim-whitespace'));
+        });
     });
 });
 

--- a/test/fixtures/base_trim-whitespace.html
+++ b/test/fixtures/base_trim-whitespace.html
@@ -1,0 +1,7 @@
+<block name="a"></block> <block name="b"></block> <block name="c"></block> <block name="d"></block>
+
+<block name="e"></block>
+
+
+
+<block name="f"></block>

--- a/test/fixtures/layout_trim-whitespace.html
+++ b/test/fixtures/layout_trim-whitespace.html
@@ -1,0 +1,8 @@
+<extends src="base.html">
+
+    <block name="f">
+        <b>^^^ 3 empty lines above me (and no empty lines below), as per base.html.</b>
+    </block>
+
+
+</extends>

--- a/test/fixtures/test_trim-whitespace.html
+++ b/test/fixtures/test_trim-whitespace.html
@@ -1,0 +1,39 @@
+<extends src="layout.html">
+
+
+    <block name="a">
+
+        No line breaks
+
+    </block>
+
+    <block name="b">
+
+        <span>are inserted,</span>
+    </block>
+
+    <block name="c">
+        because "block" and "extend" are control tags...
+    </block>
+    <block name="d">
+        <i>...which can't dictate vertical indentation.</i>
+
+
+
+    </block>
+
+
+
+
+    <block name="e">
+
+
+
+        I am indented according to the file which should control it — base.html.
+
+
+
+    </block>
+
+
+</extends>


### PR DESCRIPTION
Remove whitespace at the start/end of the first/last text node. Related: https://github.com/posthtml/posthtml-include/issues/19. 

I realized that for `posthtml-extend` it makes sense to remove not only line breaks but all whitespace instead. Because it can interfere with formatting, when actual html is inside multiple nested control tags, i.e. `<block>` inside `<extends>`:
```html
<extends src="foo.html">
    <block name="bar">
        << Parasitic whitespace to the left (as well as a line break above and below)
    </block>
</extends>
```

If there is whitespace in the middle of a string, then it remains untouched and definitely should be handled by html beautifier later:
```html
<extends src="foo.html">
    <block name="bar">
        << Parasitic whitespace to the left (as well as a line break  above and below).
        << Parasitic whitespace to the left again, this time it gets inserted to the actual output
    </block>
</extends>
```