### PR TITLE
Support for rendering multiple `<block>` tags with the same name

### DIFF
--- a/test/extend.js
+++ b/test/extend.js
@@ -261,6 +261,112 @@ describe('Extend', () => {
     });
   });
 
+  it('should extend layout with multiple blocks', () => {
+    mfs.writeFileSync('./layout.html', `
+            <div>
+                <block name="content"></block>
+                <hr>
+                <block name="content"></block>
+                <hr>
+                <block name="content"></block>
+            </div>
+        `)
+
+    return init(`
+            <extends src="layout.html">
+                <block name="content"><p>content</p></block>
+            </extends>
+        `).then(html => {
+      expect(html).toBe(cleanHtml(`
+          <div>
+              <p>content</p>
+              <hr>
+              <p>content</p>
+              <hr>
+              <p>content</p>
+          </div>
+      `))
+    });
+  });
+
+  it('should render the last <block> if multiple <block> tags with the same name are declared in <extends>', () => {
+    mfs.writeFileSync('./layout.html', `
+            <div>
+                <block name="content"></block>
+                <hr>
+                <block name="content"></block>
+                <hr>
+                <block name="content"></block>
+            </div>
+        `)
+
+    return init(`
+            <extends src="layout.html">
+                <block name="content"><p>1</p></block>
+                <block name="content"><p>2</p></block>
+                <block name="content"><p>3</p></block>
+            </extends>
+        `).then(html => {
+      expect(html).toBe(cleanHtml(`
+          <div>
+              <p>3</p>
+              <hr>
+              <p>3</p>
+              <hr>
+              <p>3</p>
+          </div>
+      `))
+    });
+  });
+
+  it('should extends layout multiple times', () => {
+    mfs.writeFileSync('./layout.html', `
+            <div>
+                <block name="content"></block>
+                <hr>
+                <block name="content"></block>
+                <hr>
+                <block name="content"></block>
+            </div>
+        `)
+
+    return init(`
+            <extends src="layout.html">
+                <block name="content"><p>1</p></block>
+            </extends>
+            <extends src="layout.html">
+                <block name="content"><p>2</p></block>
+            </extends>
+            <extends src="layout.html">
+                <block name="content"><p>3</p></block>
+            </extends>
+        `).then(html => {
+      expect(html).toBe(cleanHtml(`
+          <div>
+              <p>1</p>
+              <hr>
+              <p>1</p>
+              <hr>
+              <p>1</p>
+          </div>
+          <div>
+              <p>2</p>
+              <hr>
+              <p>2</p>
+              <hr>
+              <p>2</p>
+          </div>
+          <div>
+              <p>3</p>
+              <hr>
+              <p>3</p>
+              <hr>
+              <p>3</p>
+          </div>
+      `))
+    });
+  });
+
   it('should throw an error if <extends> has no "src"', () => {
     return assertError(
       init('<extends><block name="content"></block></extends>'),


### PR DESCRIPTION
## Overview

Hi, there.

I encountered the similar issue with #47. I created `content.html` like below, but couldn't get expected result.

```html
<!-- content.html -->
<extends src="layout.html">
    <fill name="content"><p>content</p></fill>
</extends>
```

```html
<!-- layout.html -->
<div>
    <slot name="content"></slot>
    <slot name="content"></slot>
    <slot name="content"></slot>
</div>
```

### Expected behavior

```html
<div>
    <p>content</p>
    <p>content</p>
    <p>content</p>
</div>
```

### Actual behavior

```html
<div>
    <slot name="content"></slot>
    <slot name="content"></slot>
    <p>content</p>
</div>
```

This PR is a patch for this issue.

## Changes

- internally, `blockNodes`, which is return value of `getBlockNodes` function has arrays of PostHTML Node in each key (`Record<string, Node[]>`)
- render the last <block> if multiple <block> tags with the same name are declared in `<extends>`
  - See [the test case](https://github.com/posthtml/posthtml-extend/pull/50/files#diff-9f25de2d6c4fa9380d80765b92c670f283e0a79da73e1d92dc111944f79b8669R292-R320) for detail

## Related

- close #47
