### PR TITLE
fix: copy options.expressions into new object to not pollute locals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,8 +50,10 @@ function handleExtendsNodes(tree, options, messages) {
       } catch {}
     }
 
-    options.expressions.locals = merge(options.expressions.locals, locals);
-    const plugins = [...options.plugins, expressions(options.expressions)];
+    const plugins = [...options.plugins, expressions({
+      ...options.expressions,
+      locals: merge(options.expressions.locals, locals)
+    })];
 
     const layoutPath = path.resolve(options.root, extendsNode.attrs.src);
     const layoutHtml = fs.readFileSync(layoutPath, options.encoding);

--- a/test/extend.js
+++ b/test/extend.js
@@ -428,11 +428,11 @@ describe('Extend', () => {
   });
 
   /*
-    This plugin merges the locals from options.expressions.locals and the
+    This plugin used to merge the locals from options.expressions.locals and the
     "locals" attribute into the options.expressions.locals property. Arrays in
-    the attribute locals will be copied into options.expressions.locals and when
-    the plugin is called again they will be merged again, doubling all array
-    entries every time the plugin is called.
+    the attribute locals would be copied into options.expressions.locals and
+    when the plugin was called again they would be merged again, doubling all
+    array entries every time the plugin was called.
   */
   it('should not pollute options.expression.locals ', async () => {
     mfs.writeFileSync('./base.html', `<div class="base">{{ list.join(", ") }}</div>`);
@@ -452,8 +452,8 @@ describe('Extend', () => {
     expect(await init(preHtml, options)).toBe(postHtml);
     expect(options.expressions.locals).toStrictEqual({});
     /*
-      Since the entries in "list" have been merged with themselves, the content
-      would be "One, Two, Three, One, Two, Three"
+      Since the entries in "list" would have been merged with themselves, the
+      content would have been "One, Two, Three, One, Two, Three"
     */
     expect(await init(preHtml, options)).toBe(postHtml);
   });


### PR DESCRIPTION
This plugin merges the locals from `options.expressions.locals` and the `locals` attribute into the `options.expressions.locals` property. Arrays in the `locals` attribute will be copied into `options.expressions.locals` and when the plugin is called again they will be merged again, doubling all array entries every time the plugin is called.

https://github.com/posthtml/posthtml-extend/blob/ccf454a4b0ead941626bd7c09aae79c0e8c2388c/src/index.js#L53-L54

I fixed that by copying the `options.expressions` object into a new object.

```js
const plugins = [...options.plugins, expressions({
  ...options.expressions,
  locals: merge(options.expressions.locals, locals)
})];
```

I added a test which checks if `options.expressions.locals` stays the same after rendering with the plugin. Run the GitHub Action for the commit [test: add test for options.expressions.locals pollution](https://github.com/posthtml/posthtml-extend/commit/de0be4a3a2c31cf6342b786ca987ebc846f8ab1c) to see the failing test. Run Actions for latest commit for succeeding tests.